### PR TITLE
No error 500 for nonexistent city

### DIFF
--- a/src/main/webapp/index.ftl
+++ b/src/main/webapp/index.ftl
@@ -45,7 +45,7 @@
             <div class="city">
                 <span class="pull-right">
                 <#if model??>
-                ${model.getCity()}
+                ${model.getCity()!"Invalid city name"}
                 <#else>???</#if>
                 </span>
             </div>
@@ -55,8 +55,8 @@
         <div class="col-xs-6 col-xs-offset-6">
             <div class="temperature">
                 <span class="pull-right">
-                <#if model??>
-                ${model.getHumanisedTemperature()}
+                <#if model?? && model.getCity()??>
+                ${model.getHumanizedTemperature()}
                 <#else>???</#if>
                 </span>
             </div>


### PR DESCRIPTION
Added default behavior for trying to get weather of nonexistent city (instead of just showing error 500)
