### PR TITLE
No error 500 for nonexistent cities 

### DIFF
--- a/src/main/java/ru/yandex/autoschool/weather/services/WeatherService.java
+++ b/src/main/java/ru/yandex/autoschool/weather/services/WeatherService.java
@@ -33,6 +33,9 @@ public class WeatherService {
 
         OpenWeatherDetails response = service.getWeather(weatherQuery);
         Weather weather = new Weather();
+        if (response.getCity() == null) {
+            return  weather;
+        }
         weather.setTemperature(WeatherMeasure.KELVIN.toCelsius(response.getStatus().getTemperature()));
         weather.setMeasure(WeatherMeasure.CELSIUS);
         weather.setCity(response.getCity());

--- a/src/main/webapp/index.ftl
+++ b/src/main/webapp/index.ftl
@@ -45,7 +45,7 @@
             <div class="city">
                 <span class="pull-right">
                 <#if model??>
-                ${model.getCity()}
+                ${model.getCity()!"Invalid city name"}
                 <#else>???</#if>
                 </span>
             </div>
@@ -55,7 +55,7 @@
         <div class="col-xs-6 col-xs-offset-6">
             <div class="temperature">
                 <span class="pull-right">
-                <#if model??>
+                <#if model?? && model.getCity()??>
                 ${model.getHumanizedTemperature()}
                 <#else>???</#if>
                 </span>

--- a/src/test/java/ru/yandex/autoschool/weather/web/WeatherTest.java
+++ b/src/test/java/ru/yandex/autoschool/weather/web/WeatherTest.java
@@ -22,6 +22,8 @@ public class WeatherTest {
     private WebDriver driver = new PhantomJSDriver();
 
     private String baseUrl = "http://localhost:8080";
+    private String invalidCityUrl = baseUrl + "/thereisnosuchvity";
+    private String invalidCityCaption = "Invalid city name";
 
     @Before
     public void openHomePage() {
@@ -40,6 +42,18 @@ public class WeatherTest {
         String temperature = driver.findElement(By.className("temperature")).getText();
         assertThat(temperature, notNullValue());
         assertThat(temperature, endsWith(WeatherMeasure.CELSIUS.getAbbreviation()));
+    }
+
+    @Test
+    public void invalidCityTest() {
+        driver.get(invalidCityUrl);
+        String city = driver.findElement(By.className("city")).getText();
+        assertThat(city, notNullValue());
+        assertThat(city, equalTo(invalidCityCaption));
+        String temperature = driver.findElement(By.className("temperature")).getText();
+        assertThat(temperature, notNullValue());
+        assertThat(temperature, equalTo("???"));
+        driver.get(baseUrl);
     }
 
 


### PR DESCRIPTION
Added default behavior for trying to get weather of invalid (nonexistent) city instead of showing error 500 page.
